### PR TITLE
Fixed test

### DIFF
--- a/ch07/AccountManagement/src/test/groovy/mjg/spring/services/AccountProcessorSpec.groovy
+++ b/ch07/AccountManagement/src/test/groovy/mjg/spring/services/AccountProcessorSpec.groovy
@@ -35,13 +35,14 @@ class AccountProcessorSpec extends Specification {
     def "processing test accounts should yield 3"() {
         given:
         def accounts = dao.findAllAccounts()
+        accountProcessor.setAccounts(accounts)
          
         when: 
         def result = accountProcessor.processAccounts()
         
         then:
         result == 3.0
-        accounts.every { account ->
+        accountProcessor.getAccounts().every { account ->
              account.balance.toString().endsWith "9"   
         }
     }


### PR DESCRIPTION
accountProcessor's List<Account> was not being set. When asserting that all accounts end with "9", it's being done on the accounts in the database (which are all "0").

Added List<Account> to accountProcessor, then getting the accounts from there when asserting.
